### PR TITLE
Don't wait to status without run executions

### DIFF
--- a/cloudify_deployment_proxy/README.md
+++ b/cloudify_deployment_proxy/README.md
@@ -285,14 +285,19 @@ $ cfy install cloudify-utilities-plugin/cloudify_deployment_proxy/examples/deplo
 # reuse deployment
 
 ```shell
-#
 $ cfy install cloudify-utilities-plugin/cloudify_deployment_proxy/examples/deployment-proxy-custom-workflow.yaml -b three -d three
 ````
 
+# reuse only outputs from one
+
+```shell
+cfy install cloudify-utilities-plugin/cloudify_deployment_proxy/examples/deployment-without-workflow.yaml -b four -d four
+````
 
 # delete all
 
 ```shell
+$ cfy uninstall four
 $ cfy uninstall three
 $ cfy uninstall two
 $ cfy uninstall one

--- a/cloudify_deployment_proxy/__init__.py
+++ b/cloudify_deployment_proxy/__init__.py
@@ -276,9 +276,9 @@ class DeploymentProxyBase(object):
                      **execution_args)
             self.dp_get_client_response('executions', EXEC_START, client_args)
 
-        # Poll for execution success.
-        if not self.verify_execution_successful():
-            ctx.logger.error('Deployment error.')
+            # Poll for execution success.
+            if not self.verify_execution_successful():
+                ctx.logger.error('Deployment error.')
 
         if NIP_TYPE == ctx.node.type:
             return self.post_execute_node_instance_proxy()

--- a/cloudify_deployment_proxy/examples/deployment-without-workflow.yaml
+++ b/cloudify_deployment_proxy/examples/deployment-without-workflow.yaml
@@ -4,25 +4,16 @@ imports:
   - http://www.getcloudify.org/spec/cloudify/4.0/types.yaml
   - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
-inputs:
-
-  bp_dep_archive:
-    default: https://github.com/EarthmanT/the-not-blueprint/archive/master.zip
-
 node_templates:
 
-  node_instance_proxy:
-    type: cloudify.nodes.NodeInstanceProxy
+  deployment_proxy:
+    type: cloudify.nodes.DeploymentProxy
     properties:
       resource_config:
         blueprint:
-          id: deployment_proxy
-          blueprint_archive: { get_input: bp_dep_archive }
-          main_file_name: blueprint.yaml
+          external_resource: true
         deployment:
+          external_resource: true
           id: deployment_proxy
           outputs:
             key: deployment_proxy_output
-        node_instance:
-          node:
-            id: not_a_node_template

--- a/cloudify_deployment_proxy/polling.py
+++ b/cloudify_deployment_proxy/polling.py
@@ -93,7 +93,7 @@ def dep_logs_redirect(_client, execution_id):
 
     while full_count > last_event:
         events, full_count = _client.events.get(execution_id, last_event,
-                                                last_event + 100, True)
+                                                250, True)
         for event in events:
 
             instance_prompt = event.get('node_instance_id', "")

--- a/cloudify_ssh_key/examples/import-simple-manager.yaml
+++ b/cloudify_ssh_key/examples/import-simple-manager.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0.1/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.2/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
 inputs:
 

--- a/cloudify_ssh_key/examples/ssh-key-blueprint.yaml
+++ b/cloudify_ssh_key/examples/ssh-key-blueprint.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0.1/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.2/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
 node_templates:
 

--- a/cloudify_terminal/examples/cisco.yaml
+++ b/cloudify_terminal/examples/cisco.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.2/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
 inputs:
 

--- a/cloudify_terminal/examples/fortigate.yaml
+++ b/cloudify_terminal/examples/fortigate.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.2/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
 inputs:
 

--- a/cloudify_terminal/examples/linux-ssh.yaml
+++ b/cloudify_terminal/examples/linux-ssh.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0/types.yaml
-  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.2/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-incubator/cloudify-utilities-plugin/1.2.3/plugin.yaml
 
 inputs:
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,9 @@ deps =
 commands =
     # deployment proxy examples
     cfy blueprint validate cloudify_deployment_proxy/examples/deployment-proxy.yaml
-    # uncomment after release
-    # cfy blueprint validate cloudify_deployment_proxy/examples/deployment-proxy-reuse.yaml
-    # cfy blueprint validate cloudify_deployment_proxy/examples/deployment-proxy-custom-workflow.yaml
+    cfy blueprint validate cloudify_deployment_proxy/examples/deployment-proxy-reuse.yaml
+    cfy blueprint validate cloudify_deployment_proxy/examples/deployment-proxy-custom-workflow.yaml
+    cfy blueprint validate cloudify_deployment_proxy/examples/deployment-without-workflow.yaml
     cfy blueprint validate cloudify_deployment_proxy/examples/node-instance-proxy.yaml
     # ssh examples
     cfy blueprint validate cloudify_ssh_key/examples/import-simple-manager.yaml
@@ -46,6 +46,6 @@ commands =
     # cfy blueprint validate cloudify_ssh_key/examples/azure-blueprint.yaml
     # uncomment after release
     # terminal examples
-    # cfy blueprint validate cloudify_terminal/example/fortigate.yaml
-    # cfy blueprint validate cloudify_terminal/example/cisco.yaml
-    # cfy blueprint validate cloudify_terminal/example/linux-ssh.yaml
+    cfy blueprint validate cloudify_terminal/examples/fortigate.yaml
+    cfy blueprint validate cloudify_terminal/examples/cisco.yaml
+    cfy blueprint validate cloudify_terminal/examples/linux-ssh.yaml


### PR DESCRIPTION
Fix issue with hang on get outputs from other deployment without run workflow.

With such fix: uninstall hanging in waiting to finish uninstall when we really don't start any new executions.