### PR TITLE
Cloudify rest: retry_on_connection_error flag added

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,3 +81,6 @@ releases:
 
   v.1.5.2:
   - Bug fix for empty deployment outputs in deployment proxy.
+
+  v.1.5.3:
+  - Handle retries in REST type.

--- a/cloudify_rest/README.md
+++ b/cloudify_rest/README.md
@@ -42,6 +42,7 @@ Template parameters:
 - **response_translation** - translates response into runtime properties (please see example)
 - **response_expectation** - what we expect in a response content. If response is different than specified, system is raising recoverable error and trying until response is equal to specified
 - **nonrecoverable_response** - response which is raising non-recoverable error and triggers workflow to stop (give up)
+- **retry_on_connection_error** - try to send request again even in case when REST endpoint is not available (ConnectionError). It may be useful in cases that we need to wait for some REST service to be up.
 
 
 ```

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,8 +3,8 @@ plugins:
   cfy_util: &utilities_plugin
     executor: central_deployment_agent
     package_name: cloudify-utilities-plugin
-    source: https://github.com/cloudify-incubator/cloudify-utilities-plugin/archive/1.5.2.zip
-    package_version: '1.5.2'
+    source: https://github.com/cloudify-incubator/cloudify-utilities-plugin/archive/1.5.3.zip
+    package_version: '1.5.3'
 
   cfy_files: *utilities_plugin
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugin',
-    version='1.5.2',
+    version='1.5.3',
     author='Gigaspaces.com',
     author_email='hello@getcloudify.org',
     description='Utilities for extending Cloudify',


### PR DESCRIPTION
Sometime we need to wait for some REST API to be up (device is starting) and then send some request. For now it was impossible to use rest plugin for this purpose - NonRecoverableError had been raised in case when API was done (ConnectionError from Requests). I added optional flag in REST request template: retry_on_connection_error. When it is set to true plugin will retry operation (RecoverableError) instead of raising NonRecoverableError. This feature is needed for one of customer project.