### PR TITLE
Cloudify rest: unmet response exectation causing recoverable error

### DIFF
--- a/cloudify_rest/rest_sdk/utility.py
+++ b/cloudify_rest/rest_sdk/utility.py
@@ -103,8 +103,10 @@ def _send_request(call):
                 raise
 
     logger.info(
-        'Response \n text:{}\n status_code:{}\n'.format(response.text,
-                                                        response.status_code))
+        'Response \n content:{}\n status_code:{}\n'
+        .format(response.content, response.status_code)
+    )
+
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
@@ -184,7 +186,7 @@ def _check_response(json, response, is_recoverable):
                 json = json[key]
             except (IndexError, KeyError):
                 raise ExpectationException(
-                        'No key or index {} in json {}'.format(key, json))
+                        'No key or index "{}" in json {}'.format(key, json))
 
         if re.match(str(pattern), str(json)) and not is_recoverable:
             raise NonRecoverableResponseException(

--- a/cloudify_rest/tasks.py
+++ b/cloudify_rest/tasks.py
@@ -55,7 +55,8 @@ def _execute(params, template_file, instance, node):
         raise NonRecoverableError(e)
 
     except (exceptions.RecoverableResponseException,
-            exceptions.RecoverableStatusCodeCodeException)as e:
+            exceptions.RecoverableStatusCodeCodeException,
+            exceptions.ExpectationException)as e:
         raise RecoverableError(e)
     except Exception as e:
         ctx.logger.info(


### PR DESCRIPTION
Incorrect behaviour of **response_expectation** mechanism fixed. In readme file response_expectation is describe as: _"what we expect in a response content. If response is different than specified, system is raising **recoverable error** and trying until response is equal to specified"_. For now it raised **NonRecoverableError** instead of **RecoverableError** (ExpectationException cached in general except here: https://github.com/cloudify-incubator/cloudify-utilities-plugin/blob/master/cloudify_rest/tasks.py#L60).

This change also fixes "UnicodeEncodeError: 'ascii' codec can't encode character ..." spotted here: https://github.com/cloudify-incubator/cloudify-utilities-plugin/blob/master/cloudify_rest/rest_sdk/utility.py#L106

Change needed for one of customers project.