### PR TITLE
Added possibility to use jinja blocks inside template file for rest p…

### DIFF
--- a/cloudify_rest/rest_sdk/utility.py
+++ b/cloudify_rest/rest_sdk/utility.py
@@ -58,7 +58,7 @@ def process(params, template, request_props):
             'call_with_request_props \n {}'.format(call_with_request_props))
         response = _send_request(call_with_request_props)
         _process_response(response, call, result_propeties)
-    result_propeties = {'result_propeties':result_propeties,'calls':calls}
+    result_propeties = {'result_propeties': result_propeties, 'calls': calls}
     return result_propeties
 
 

--- a/cloudify_rest/tests/template6.yaml
+++ b/cloudify_rest/tests/template6.yaml
@@ -1,0 +1,10 @@
+rest_calls:
+  - path: /v1/post_jinja_block
+    method: POST
+    headers:
+      Content-type: test/type
+    payload:
+      key: value
+      jinja_block:
+        "{% if custom_list is not string %}{{custom_list}}{% endif %}"
+    response_format: raw

--- a/cloudify_rest/tests/test_plugin.py
+++ b/cloudify_rest/tests/test_plugin.py
@@ -201,7 +201,6 @@ class TestPlugin(unittest.TestCase):
         _ctx.logger.setLevel(logging.DEBUG)
         current_ctx.set(_ctx)
         custom_list = [ {'key1':'val1'}, {'key2':'val2'}, ['element1', 'element2'] ]
-        print custom_list
         params = {'custom_list': custom_list}
 
         with requests_mock.mock(

--- a/cloudify_rest/tests/test_plugin.py
+++ b/cloudify_rest/tests/test_plugin.py
@@ -70,7 +70,7 @@ class TestPlugin(unittest.TestCase):
             tasks.execute(params, 'mock_param')
             # _ctx = current_ctx.get_ctx()
             self.assertDictEqual(
-                _ctx.instance.runtime_properties,
+                _ctx.instance.runtime_properties.get('result_propeties'),
                 {'nested_key0': u'nested_value1',
                  'nested_key1': u'nested_value2',
                  'id0': u'1',
@@ -182,6 +182,34 @@ class TestPlugin(unittest.TestCase):
             tasks.execute({}, 'mock_param')
             # _ctx = current_ctx.get_ctx()
             self.assertDictEqual(
-                _ctx.instance.runtime_properties,
+                _ctx.instance.runtime_properties.get('result_propeties'),
                 {'UUID': '111111111111111111111111111111',
                  'CPUID': 'ABS:FFF222777'})
+
+    def test_execute_jinja_block_parse(self):
+        _ctx = MockCloudifyContext('node_name',
+                                   properties={'hosts': ['test123.test'],
+                                               'port': -1,
+                                               'ssl': False,
+                                               'verify': False},
+                                   runtime_properties={})
+        __location__ = os.path.realpath(
+            os.path.join(os.getcwd(), os.path.dirname(__file__)))
+        with open(os.path.join(__location__, 'template6.yaml'), 'r') as f:
+            template = f.read()
+        _ctx.get_resource = MagicMock(return_value=template)
+        _ctx.logger.setLevel(logging.DEBUG)
+        current_ctx.set(_ctx)
+        custom_list = [ {'key1':'val1'}, {'key2':'val2'}, ['element1', 'element2'] ]
+        print custom_list
+        params = {'custom_list': custom_list}
+
+        with requests_mock.mock(
+                real_http=True) as m:
+
+            m.post('http://test123.test:80/v1/post_jinja_block',
+                   text="resp")
+
+            tasks.execute(params, 'mock_param')
+            parsed_list = _ctx.instance.runtime_properties.get('calls')[0].get('payload').get('jinja_block')
+            self.assertListEqual( parsed_list, custom_list)

--- a/cloudify_rest/tests/test_plugin.py
+++ b/cloudify_rest/tests/test_plugin.py
@@ -200,7 +200,9 @@ class TestPlugin(unittest.TestCase):
         _ctx.get_resource = MagicMock(return_value=template)
         _ctx.logger.setLevel(logging.DEBUG)
         current_ctx.set(_ctx)
-        custom_list = [ {'key1':'val1'}, {'key2':'val2'}, ['element1', 'element2'] ]
+        custom_list = [{'key1': 'val1'},
+                       {'key2': 'val2'},
+                       ['element1', 'element2']]
         params = {'custom_list': custom_list}
 
         with requests_mock.mock(
@@ -210,5 +212,6 @@ class TestPlugin(unittest.TestCase):
                    text="resp")
 
             tasks.execute(params, 'mock_param')
-            parsed_list = _ctx.instance.runtime_properties.get('calls')[0].get('payload').get('jinja_block')
-            self.assertListEqual( parsed_list, custom_list)
+            parsed_list = _ctx.instance.runtime_properties.get(
+                'calls')[0].get('payload').get('jinja_block')
+            self.assertListEqual(parsed_list, custom_list)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,7 +4,7 @@ plugins:
     executor: central_deployment_agent
     package_name: cloudify-utilities-plugin
     source: https://github.com/cloudify-incubator/cloudify-utilities-plugin/archive/1.7.1.zip
-    package_version: '1.7.1'
+    package_version: '1.7.2'
 
   cfy_files: *utilities_plugin
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugin',
-    version='1.7.1',
+    version='1.7.2',
     author='Gigaspaces.com',
     author_email='hello@getcloudify.org',
     description='Utilities for extending Cloudify',


### PR DESCRIPTION
…lugin.

Currently we can create the jinja blocks inside template file, but it has to be contained as a string (inside quotes). As the result every value returned from jinja block will be inside quotes what is only valid for string values, but when the complex structure is generated from jinja block (list, dict) then the quotes causes error while evaluation. 

The proposed solution is to pass values that are not string always inside a jinja block, so instead of passing list inside template like this (which won't work):
"{{custom_list}}"
Now it can be passed like this:
"{% if custom_list is not string %}{{custom_list}}{% endif %}"
Plugin will erase quotes before and after every jinja block and then will evaluate the generated string as it suppose to without errors.  