### PR TITLE
scalelist: wait for running tasks before calling _uninstall

### DIFF
--- a/cloudify_scalelist/workflows.py
+++ b/cloudify_scalelist/workflows.py
@@ -395,6 +395,7 @@ def _run_scale_settings(ctx, scale_settings, scalable_entity_properties,
             except Exception as ex:
                 ctx.logger.error('Scale out failed, scaling back in. {}'
                                  .format(repr(ex)))
+                _wait_for_sent_tasks(ctx, graph)
                 _uninstall_instances(ctx=ctx,
                                      graph=graph,
                                      removed=added,
@@ -424,6 +425,7 @@ def _run_scale_settings(ctx, scale_settings, scalable_entity_properties,
                             )
                         )
             related = removed_and_related - removed
+            _wait_for_sent_tasks(ctx, graph)
             _uninstall_instances(ctx=ctx,
                                  graph=graph,
                                  removed=removed,
@@ -434,24 +436,29 @@ def _run_scale_settings(ctx, scale_settings, scalable_entity_properties,
         ctx.logger.warn('Rolling back deployment modification. '
                         '[modification_id={0}]: {1}'
                         .format(modification.id, repr(ex)))
-        try:
-            deadline = time.time() + ctx.wait_after_fail
-        except AttributeError:
-            deadline = time.time() + 1800
-        while deadline > time.time():
-            if graph._is_execution_cancelled():
-                raise api.ExecutionCancelled()
-            for task in graph._terminated_tasks():
-                graph._handle_terminated_task(task)
-            if not any(task.get_state() == tasks.TASK_SENT
-                       for task in graph.tasks_iter()):
-                break
-            else:
-                time.sleep(0.1)
+        _wait_for_sent_tasks()
         modification.rollback()
         raise ex
     else:
         modification.finish()
+
+
+def _wait_for_sent_tasks(ctx, graph):
+    """Wait for tasks that are in the SENT state to return"""
+    try:
+        deadline = time.time() + ctx.wait_after_fail
+    except AttributeError:
+        deadline = time.time() + 1800
+    while deadline > time.time():
+        if graph._is_execution_cancelled():
+            raise api.ExecutionCancelled()
+        for task in graph._terminated_tasks():
+            graph._handle_terminated_task(task)
+        if not any(task.get_state() == tasks.TASK_SENT
+                   for task in graph.tasks_iter()):
+            break
+        else:
+            time.sleep(0.1)
 
 
 def _scaledown_group_to_settings(ctx, list_scale_groups, scale_compute):


### PR DESCRIPTION
_uninstall_instances clears the graph, so if we are to wait for
sent tasks, we must do it before clearing.